### PR TITLE
fix: Actualizar año en trabajo actual de 2024-2025 a actualización au…

### DIFF
--- a/assets/js/main_moderno.js
+++ b/assets/js/main_moderno.js
@@ -39,6 +39,7 @@ function initializeApp() {
     initializeTypingEffect();
     initializeSkillBars();
     initializeTimelineAnimations();
+    updateCurrentJobYear();
     initializeProjectFilters();
     initializeContactForm();
     initializePerformanceOptimizations();
@@ -372,6 +373,29 @@ function initializeTimelineAnimations() {
     timelineItems.forEach(item => {
         timelineObserver.observe(item);
     });
+}
+
+/**
+ * Actualiza automáticamente el año en trabajos actuales
+ */
+function updateCurrentJobYear() {
+    const currentJobElements = document.querySelectorAll('.timeline-year[data-current="true"]');
+    const currentYear = new Date().getFullYear();
+
+    currentJobElements.forEach(element => {
+        const startYear = element.getAttribute('data-start-year');
+        if (startYear) {
+            // Si es el mismo año de inicio, mostrar solo "2024-Actual"
+            // Si ya pasó el año, mostrar "2024-2025" (o el año actual)
+            if (parseInt(startYear) === currentYear) {
+                element.textContent = `${startYear}-Actual`;
+            } else {
+                element.textContent = `${startYear}-${currentYear}`;
+            }
+        }
+    });
+
+    console.log(`✅ Año de trabajo actual actualizado: ${currentYear}`);
 }
 
 /**

--- a/index.html
+++ b/index.html
@@ -375,11 +375,11 @@
 
             <div class="timeline" data-aos="fade-up" data-aos-duration="1000">
                 
-                <!-- 2024-2025: Software Engineer Consultant -->
+                <!-- 2024-Actual: Software Engineer Consultant -->
                 <div class="timeline-item" data-aos="fade-right" data-aos-delay="100">
                     <div class="timeline-marker current"></div>
                     <div class="timeline-content">
-                        <div class="timeline-year">2024-2025</div>
+                        <div class="timeline-year" data-start-year="2024" data-current="true">2024-Actual</div>
                         <h3><i class="fas fa-laptop-code me-2"></i>Software Engineer Consultant</h3>
                         <h4>Amaris Consulting</h4>
                         <p>Especialización en desarrollo y optimización de APIs y microservicios con Java, Spring Boot y Quarkus. Implementación de prácticas CI/CD y arquitecturas escalables.</p>


### PR DESCRIPTION
…tomática

🔧 Problema corregido:
- La sección "Software Engineer Consultant" mostraba "2024-2025"
- Esto daba a entender que el trabajo había finalizado
- El usuario sigue trabajando activamente en Amaris Consulting

✅ Solución implementada:
- Cambio de "2024-2025" a "2024-Actual" en HTML
- Añadido atributo data-current="true" para trabajos actuales
- Añadido atributo data-start-year="2024" para cálculo dinámico

🚀 Función JavaScript automática:
- Nueva función updateCurrentJobYear() en main_moderno.js
- Actualiza automáticamente el año según la fecha actual
- Lógica inteligente:
  * Si estamos en 2024: muestra "2024-Actual"
  * Si estamos en 2025: muestra "2024-2025"
  * Si estamos en 2026: muestra "2024-2026"
  * Y así sucesivamente...

📍 Archivos modificados:
- index.html: línea 382 (timeline-year con data attributes)
- main_moderno.js: líneas 381-399 (nueva función updateCurrentJobYear)

Ahora el timeline refleja correctamente que es un trabajo ACTUAL en curso.